### PR TITLE
Fixed #3, Replace Base64 with low quality placeholder

### DIFF
--- a/Lazyload.class.php
+++ b/Lazyload.class.php
@@ -17,7 +17,7 @@ class Lazyload {
         if (defined('MW_API') && $wgRequest->getVal('action') === 'parse') return true;
         if (isset($wgTitle) && $wgTitle->getNamespace() === NS_FILE) return true;
         $attribs['data-url'] = $attribs['src'];
-        $attribs['src'] = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+        $attribs['src'] = preg_replace('#/\d+px-#', '/10px-', $attribs['src']);
         if (isset($attribs['srcset'])) {
             $attribs['data-srcset'] = $attribs['srcset'];
             unset($attribs['srcset']);


### PR DESCRIPTION
Replaced placeholder image with 10px version of the thumbnail, since it has an actual src, it also fixed the Multimedia Viewer issue (#3) 